### PR TITLE
Fix typos and routing bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ It demonstrates the deployment of a VPC, RDS database, ALB (Application Load Bal
 ```bash
 git clone https://github.com/Eliya-shlomo/WEB_endTOend.git
 cd WEB_endTOend
+```
+
+2. **Initialize Terraform**:
+
+```bash
+terraform init
+```
+
+3. **Apply the configuration**:
+
+```bash
+terraform apply
+```

--- a/moudle/vpc/variable.tf
+++ b/moudle/vpc/variable.tf
@@ -3,7 +3,7 @@ variable "AWS_REGION" {
     default     = "us-east-2"
 }
 
-variable "MY_VPC_CIDR_BLOC" {
+variable "MY_VPC_CIDR_BLOCK" {
   description = "The CIDR block for the VPC"
   type        = string
   default     = "10.0.0.0/16"

--- a/moudle/vpc/vpc.tf
+++ b/moudle/vpc/vpc.tf
@@ -5,7 +5,7 @@ data "aws_availability_zones" "available" {
 
 # Main  vpc
 resource "aws_vpc" "my_vpc" {
-  cidr_block       = var.MY_VPC_CIDR_BLOC
+  cidr_block       = var.MY_VPC_CIDR_BLOCK
   enable_dns_support = "true"
   enable_dns_hostnames = "true"
   tags = {
@@ -153,5 +153,5 @@ output "public_subnet1_id" {
 
 output "public_subnet2_id" {
   description = "Subnet ID"
-  value       = aws_subnet.my_vpc_private_subnet_2.id
+  value       = aws_subnet.my_vpc_public_subnet_2.id
 }

--- a/variable.tf
+++ b/variable.tf
@@ -3,7 +3,7 @@ variable "AWS_REGION" {
     default     = "us-east-2"
 }
 
-variable "MY_VPC_CIDR_BLOC" {
+variable "MY_VPC_CIDR_BLOCK" {
   description = "The CIDR block for the VPC"
   type        = string
   default     = "10.0.0.0/16"

--- a/vpc.tf
+++ b/vpc.tf
@@ -4,7 +4,7 @@ data "aws_availability_zones" "available"{
 
 #Main vpc
 resource "aws_vpc" "my_vpc" {
-  cidr_block = var.MY_VPC_CIDR_BLOC
+  cidr_block = var.MY_VPC_CIDR_BLOCK
   enable_dns_support = "true"
   enable_dns_hostnames = "true"
   tags = {
@@ -128,13 +128,13 @@ resource "aws_route_table_association" "to_public_subnet_2" {
 }
 
 resource "aws_route_table_association" "to_private_subnet_1" {
-  subnet_id = aws_subnet.my_vpc_public_subnet_1.id
-  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.my_vpc_private_subnet_1.id
+  route_table_id = aws_route_table.private.id
 }
 
 resource "aws_route_table_association" "to_private_subnet_2" {
-  subnet_id = aws_subnet.my_vpc_public_subnet_2.id
-  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.my_vpc_private_subnet_2.id
+  route_table_id = aws_route_table.private.id
 }
 
 provider "aws" {

--- a/webserver/webserver_instance.tf
+++ b/webserver/webserver_instance.tf
@@ -6,7 +6,7 @@
 # }
 
 module "my-rds" {
-    source      = "../module/rds"
+    source      = "../moudle/rds"
 
     ENVIRONMENT = var.ENVIRONMENT
     AWS_REGION  = var.AWS_REGION


### PR DESCRIPTION
## Summary
- fix `MY_VPC_CIDR_BLOCK` variable name across repo
- correct route table associations for private subnets
- fix output for second public subnet
- fix module path typo
- finish README usage section

## Testing
- `terraform fmt -recursive` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f69fb912c832a86508d6bdc36189b